### PR TITLE
Disable backend 404 and 500 catch-all routes

### DIFF
--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -186,18 +186,18 @@ const router = (app) => {
   });
   
   // Error handling
-  app.use((req, res) => {
-    res.status(404).json({
-      message: "Route Not Found",
-    });
-  });
+  // app.use((req, res) => {
+  //   res.status(404).json({
+  //     message: "Route Not Found",
+  //   });
+  // });
   
-  app.use((err, req, res) => {
-    res.status(err.status || 500).json({
-      message: err.message,
-      error: {},
-    });
-  });
+  // app.use((err, req, res) => {
+  //   res.status(err.status || 500).json({
+  //     message: err.message,
+  //     error: {},
+  //   });
+  // });
 
 };
 


### PR DESCRIPTION
As discussed, the catch-all works in dev but not on prod. This PR disables generic 404/500 catch-all error handling believed to be causing the issue.