### PR TITLE
Fix a bug where a subtask checkbox did not render correctly.

### DIFF
--- a/client/src/Assets/styles/style.css
+++ b/client/src/Assets/styles/style.css
@@ -455,7 +455,7 @@ article header .ions {
 
 .round input[type="checkbox"]:checked + label:after {
   opacity: 1;
-}
+} 
 
 /* Tabs */
 

--- a/client/src/Components/SubTaskCheckBox.js
+++ b/client/src/Components/SubTaskCheckBox.js
@@ -1,15 +1,10 @@
-import React, { useState, useContext } from "react";
+import React, { useContext } from "react";
 import { GlobalContext } from "../Contexts/GlobalContext";
 
 function SubTaskCheckBox(props) {
   const { setTasksData } = useContext(GlobalContext);
 
-  // console.log(subTaskArray);
-  const completed = props.completed; // true or false
-  const [ischecked, setIsChecked] = useState(completed);
-
   const clickHandler = (e) => {
-    setIsChecked(e.target.checked);
     fetch("api/task/status", {
       method: "PUT",
       body: JSON.stringify({
@@ -35,7 +30,7 @@ function SubTaskCheckBox(props) {
           type="checkbox"
           id={props.id}
           onChange={clickHandler}
-          checked={ischecked}
+          checked={props.completed}
         />
         <label htmlFor={props.id}></label>
       </span>


### PR DESCRIPTION
If a sub-task was deleted from a task and it was checked the next sub task's status was incorrectly rendered as checked (inheriting the checked status).